### PR TITLE
Fix logout issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extension-hapi-tools",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "A set of tools and utilities to simplify the development of Auth0 Extensions with Hapi.",
   "main": "src/index.js",
   "dependencies": {


### PR DESCRIPTION
## ✏️ Changes
  
When logging out of extensions a "state already defined" error was thrown by Hapi. This PR addresses the issue by moving the state definitions out of one of the login route. 
  
## 🔗 References
  
ESD-3878 

## 🎯 Testing
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
 
  